### PR TITLE
Smarter `diff_latest!`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,13 @@ Desired features are listed below.  Note that they are in no particular order of
 - [ ] Snapshot browsing/content management
 - [ ] Test Suite
 - [ ] Logo/Mascot
+- [ ] Auto-generate secure repository passkeys
 
 [restic-backups]:https://restic.readthedocs.io
 [autorestic]:https://github.com/cupcakearmy/autorestic
 [backup-with-restic]:https://www.tomsquest.com/blog/2024/12/backup-restic-setup/
 [tomsquest]:https://github.com/tomsquest
 [backup-without-root]:https://restic.readthedocs.io/en/stable/080_examples.html#backing-up-your-system-without-running-restic-as-root
+
+## Disclaimer
+This project is still in early development, so no warranties can be made regarding its safety or the integrity of the backups it creates.  Use at your own risk.  Test and validate your backups early and often!

--- a/lib/restic/backup.rb
+++ b/lib/restic/backup.rb
@@ -43,7 +43,7 @@ module Restiby
     end
 
     def backup(backend = current_backend)
-      logger.info("Backup starting...")
+      logger.info("Backup starting for #{backend.name}...")
       restic_command.backup!(backend)
       logger.info("Backup complete")
     end

--- a/lib/restic/location.rb
+++ b/lib/restic/location.rb
@@ -1,11 +1,16 @@
+# frozen_string_literal: true
+
 module Restiby
   class Location
-    attr_reader :name, :source, :destinations
+    TAG_PREFIX = "restiby:location:"
+
+    attr_reader :name, :source, :destinations, :tag
 
     def initialize(name:, properties: {})
       @name = name
       @source = properties[:from]
       @destinations = properties[:to].map(&:to_sym)
+      @tag = "#{TAG_PREFIX}#{@name.to_s.downcase}"
     end
   end
 end


### PR DESCRIPTION
Previous implementation was naive and just comparing the latest two snapshots.  This falls apart if you have specified multiple locations for a single repository because each location ends up with its own snapshot.  So instead we'll tag each source location uniquely and then extract the latest snapshot for each.  Each snapshot's `json` content contains its own SHA ID and the SHA ID of its parent snapshot.  So use those for the diffs and join the output for each location.