### PR TITLE
Extract Common with_passkey Pattern

### DIFF
--- a/lib/restiby/backup.rb
+++ b/lib/restiby/backup.rb
@@ -20,18 +20,14 @@ module Restiby
       logger.reset
       update_restic
       config.backends.each do |backend|
-        begin
-          self.current_backend = backend
-          update_passkey_in_env(current_backend.passkey)
-
+        self.current_backend = backend
+        with_passkey(current_backend.passkey) do
           init
           backup
           check
           forget
           diff_latest
           notify_success
-        ensure
-          unset_passkey
         end
       end
       logger.info("Run completed.")

--- a/lib/restiby/check.rb
+++ b/lib/restiby/check.rb
@@ -18,12 +18,9 @@ module Restiby
     def run!
       logger.reset
       config.backends.each do |backend|
-        begin
-          self.current_backend = backend
-          update_passkey_in_env(backend.passkey)
+        self.current_backend = backend
+        with_passkey(current_backend.passkey) do
           check
-        ensure
-          unset_passkey
         end
       end
     end

--- a/lib/restiby/concerns/env_manager.rb
+++ b/lib/restiby/concerns/env_manager.rb
@@ -1,6 +1,15 @@
 module Restiby
   module Concerns
     module EnvManager
+      def with_passkey(passkey)
+        begin
+          update_passkey_in_env(passkey)
+          yield
+        ensure
+          unset_passkey
+        end
+      end
+
       def update_passkey_in_env(passkey)
         ENV["RESTIC_PASSWORD"] = passkey
       end


### PR DESCRIPTION
Noticed while starting to work on snapshot browsing/restore that there's a common pattern emerging where we need to set the password for a backend in the env, then ensure the password is dumped after the execution context wraps up.  Moved this to the `EnvManager` module so that it takes a block of commands that are safely inserted between the passkey management steps.